### PR TITLE
del the repeated torch.nn.DataParallel

### DIFF
--- a/textgen/t5/t5_model.py
+++ b/textgen/t5/t5_model.py
@@ -961,9 +961,6 @@ class T5Model:
         nb_eval_steps = 0
         model.eval()
 
-        if args.n_gpu > 1:
-            model = torch.nn.DataParallel(model)
-
         if self.args.fp16:
             from torch.cuda import amp
 


### PR DESCRIPTION
del the repeated torch.nn.DataParallel in t5_model.py, it will cause "RuntimeError: arguments are located on different GPUs" when eval t5 model with multi GPUs